### PR TITLE
Refactor UI: Replace empty IconProps interface with a type alias to satisfy lint rules

### DIFF
--- a/packages/ui/src/components/icons.tsx
+++ b/packages/ui/src/components/icons.tsx
@@ -1,4 +1,4 @@
-export interface IconProps extends React.SVGProps<SVGSVGElement> {}
+export type IconProps = React.SVGProps<SVGSVGElement>;
 
 export const Icons = {
   logo: (props: IconProps) => (


### PR DESCRIPTION
## Pull Request
Replaced the empty IconProps interface in @call/ui with a type alias to React.SVGProps<SVGSVGElement>, resolving the @typescript-eslint/no-empty-object-type lint warning.
### Description

Please include a summary of the change and relevant context. List any dependencies that are required for this change.

Fixes: #[issue_number] (if applicable)

---

### Checklist

- [x ] I have tested my changes locally
- [ ] I have added necessary documentation (if needed)
- [ ] I have added/updated tests (if applicable)
- [ x] I have run `pnpm build` or `pnpm lint` with no errors
- [ x] This pull request is ready for review

---

### Screenshots or UI Changes (if applicable)

Add screenshots, recordings, or before/after comparisons here.
before: 
![Screenshot-2025-06-23_00:50:48](https://github.com/user-attachments/assets/20f1ff4a-428d-4378-b11e-484f75718448)
after: 
![Screenshot-2025-06-23_00:51:30](https://github.com/user-attachments/assets/3034c694-a593-4e0e-9124-ed97be8f6b82)

---

### Related Issues

Reference any related issues or PRs here.

---

### Notes for Reviewer

Any special instructions, context, or things to pay attention to.
