### PR TITLE
fix: removing duplicate import of

### DIFF
--- a/apps/web/app/(waitlist)/_components/waitlist.tsx
+++ b/apps/web/app/(waitlist)/_components/waitlist.tsx
@@ -11,8 +11,6 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
-import { confettiBurst } from "@call/ui/lib/confetti";
-
 
 const formSchema = z.object({
   email: z.string().email(),


### PR DESCRIPTION
## Pull Request
removing duplicate import of : 

``` import { confettiBurst } from "@call/ui/lib/confetti";```

the duplication has thrown an error in the waitlist page: 

![Screenshot-2025-06-23_18:50:28](https://github.com/user-attachments/assets/3db727a7-72b0-4b2d-951a-516963705e93)

### Description

Please include a summary of the change and relevant context. List any dependencies that are required for this change.

Fixes: #[issue_number] (if applicable)

---

### Checklist

- [ x] I have tested my changes locally
- [ ] I have added necessary documentation (if needed)
- [ ] I have added/updated tests (if applicable)
- [ x ] I have run `pnpm build` or `pnpm lint` with no errors
- [ x ] This pull request is ready for review

---

### Screenshots or UI Changes (if applicable)

Add screenshots, recordings, or before/after comparisons here.

---

### Related Issues

Reference any related issues or PRs here.

---

### Notes for Reviewer

Any special instructions, context, or things to pay attention to.
